### PR TITLE
Update atom calibration README.md with record.launch

### DIFF
--- a/tams_pr2_atom_calibration/README.md
+++ b/tams_pr2_atom_calibration/README.md
@@ -5,7 +5,28 @@ The user should follow generally the instructions on the official [ATOM document
 
 ## Record a Bagfile
 
-To record a bagfile, use the `rosbag` command-line tool. This tool allows you to record data from one or more ROS topics for later playback.
+To record a bagfile, you can use various commands, depending on what topics you want to record.
+
+
+If you want to record all needed topics for a full calibration, please run:
+
+```sh
+roslaunch tams_pr2_atom_calibration record.launch
+```
+
+If you want to record the needed topics for a visual calibration, please run:
+
+```sh
+roslaunch tams_pr2_atom_calibration record_visual.launch
+```
+
+If you want to record the needed topics for a tactile calibration, please run:
+
+```sh
+roslaunch tams_pr2_atom_calibration record_tactile.launch
+```
+
+If you want to record a custom set of messages, you can use the `rosbag` command-line tool:
 
 ```sh
 rosbag record -O my_bagfile.bag /topic1 /topic2 ...


### PR DESCRIPTION
Changed atom calibration README to include info on how to use the record launch files, designed to create a bagfile with all needed topics. 